### PR TITLE
Fix typo "browser"

### DIFF
--- a/src/i18n/en/components/instance.json
+++ b/src/i18n/en/components/instance.json
@@ -11,7 +11,7 @@
       "domains": "Universes"
     },
     "disclaimer": {
-      "base": "Logging in process uses system broswer that, your account information won't be visible to tooot app."
+      "base": "Logging in process uses system browser that, your account information won't be visible to tooot app."
     },
     "terms": {
       "base": "By logging in, you agree to the <0>privacy policy</0> and <1>terms of service</1>."


### PR DESCRIPTION
I found typo in src/i18n/en/components/instance.json