### PR TITLE
Play audio in silent mode on iOS

### DIFF
--- a/src/startup/audio.ts
+++ b/src/startup/audio.ts
@@ -6,6 +6,7 @@ const audio = () => {
   Audio.setAudioModeAsync({
     interruptionModeIOS: InterruptionModeIOS.MixWithOthers,
     interruptionModeAndroid: InterruptionModeAndroid.DuckOthers,
+    playsInSilentModeIOS: true,
     staysActiveInBackground: false
   })
 }


### PR DESCRIPTION
Setting `playsInSilentModeIOS` audio mode flag so that we can still hear the sounds in videos when silent mode is on.