### PR TITLE
Fix the "undefined" string in DM

### DIFF
--- a/src/screens/Compose.tsx
+++ b/src/screens/Compose.tsx
@@ -168,7 +168,7 @@ const ScreenCompose: React.FC<RootStackScreenProps<'Screen-Compose'>> = ({
           textInput: 'text',
           composeDispatch,
           content:
-            (params.text && `${params.text}\n`) +
+            (params.text ? `${params.text}\n` : '') +
             params.accts.map(acct => `@${acct}`).join(' ') +
             ' ',
           disableDebounce: true


### PR DESCRIPTION
When posting DM from account page conversation icon, there is always a "undefined" at the beginning. The reason is that the following expression evaluates to `undefined` if `params.text` is `undefined` (it is only assigned when sending diagnostic information to Tooot support).

```
params.text && `${params.text}\n`
```

This change fixes it with a tenary expression.