### PR TITLE
Patch expo-av to fix audio issue when switched to background on iOS

### DIFF
--- a/patches/expo-av+13.0.2.patch
+++ b/patches/expo-av+13.0.2.patch
@@ -1,0 +1,14 @@
+diff --git a/node_modules/expo-av/ios/EXAV/EXAudioSessionManager.m b/node_modules/expo-av/ios/EXAV/EXAudioSessionManager.m
+index 81dce13..8664b90 100644
+--- a/node_modules/expo-av/ios/EXAV/EXAudioSessionManager.m
++++ b/node_modules/expo-av/ios/EXAV/EXAudioSessionManager.m
+@@ -168,9 +168,6 @@ - (void)moduleDidBackground:(id)backgroundingModule
+   // compact doesn't work, that's why we need the `|| !pointer` above
+   // http://www.openradar.me/15396578
+   [_foregroundedModules compact];
+-
+-  // Any possible failures are silent
+-  [self _updateSessionConfiguration];
+ }
+ 
+ - (void)moduleDidForeground:(id)module


### PR DESCRIPTION
Package `expo-av` always set audio session category to `AVAudioSessionCategorySoloAmbient` when app is switched to background. However it does not deactivate the audio session and non-mixable audios in other apps such as Spotify stops playing. This change provides a patch to `expo-av` to workaround it first.