### PR TITLE
Text wrapping workaround in toot composing screen

### DIFF
--- a/src/screens/Compose/Root/Header/TextInput.tsx
+++ b/src/screens/Compose/Root/Header/TextInput.tsx
@@ -33,7 +33,8 @@ const ComposeTextInput: React.FC = () => {
         paddingBottom: StyleConstants.Spacing.M,
         marginHorizontal: StyleConstants.Spacing.Global.PagePadding,
         color: colors.primaryDefault,
-        borderBottomColor: colors.border,
+        borderBottomWidth: 0.5,
+        borderBottomColor: colors.backgroundDefaultTransparent,
         fontSize: adaptedFontsize,
         lineHeight: adaptedLineheight
       }}


### PR DESCRIPTION
It seems that if `borderBottomWidth` needs to be set to make text wrapping work in toot composing screen. But it will make the bottom border appear so we also need to set the its color to `backgroundDefaultTransparent`.

This shall fix #472 and fix #513.