### PR TITLE
Fix "Show boosts" "Show replies" toggles

### DIFF
--- a/src/screens/Tabs/Local/Root.tsx
+++ b/src/screens/Tabs/Local/Root.tsx
@@ -61,7 +61,7 @@ const Root: React.FC<NativeStackScreenProps<TabLocalStackParamList, 'Tab-Local-R
               />
               {page.page === 'Following' && !instanceFollowingPage.showBoosts ? (
                 <Icon
-                  name='MessageCircle'
+                  name='Repeat'
                   size={StyleConstants.Font.Size.M}
                   color={colors.red}
                   style={{ marginLeft: StyleConstants.Spacing.S }}
@@ -70,7 +70,7 @@ const Root: React.FC<NativeStackScreenProps<TabLocalStackParamList, 'Tab-Local-R
               ) : null}
               {page.page === 'Following' && !instanceFollowingPage.showReplies ? (
                 <Icon
-                  name='Repeat'
+                  name='MessageCircle'
                   size={StyleConstants.Font.Size.M}
                   color={colors.red}
                   style={{ marginLeft: StyleConstants.Spacing.S }}

--- a/src/screens/Tabs/Local/Root.tsx
+++ b/src/screens/Tabs/Local/Root.tsx
@@ -100,7 +100,7 @@ const Root: React.FC<NativeStackScreenProps<TabLocalStackParamList, 'Tab-Local-R
               </DropdownMenu.Item>
               <DropdownMenu.CheckboxItem
                 key='showBoosts'
-                value={instanceFollowingPage.showBoosts ? 'on' : 'mixed'}
+                value={instanceFollowingPage.showBoosts ? 'on' : 'off'}
                 onValueChange={() => {
                   setQueryKey([
                     'Timeline',
@@ -120,7 +120,7 @@ const Root: React.FC<NativeStackScreenProps<TabLocalStackParamList, 'Tab-Local-R
               </DropdownMenu.CheckboxItem>
               <DropdownMenu.CheckboxItem
                 key='showReplies'
-                value={instanceFollowingPage.showReplies ? 'on' : 'mixed'}
+                value={instanceFollowingPage.showReplies ? 'on' : 'off'}
                 onValueChange={() => {
                   setQueryKey([
                     'Timeline',


### PR DESCRIPTION
After unchecking "Show replies" toggle, there're 2 UI errors:
1. The wrong icon is used
    **CORRECT** icon should be:
    + replies -> `MessageCircle`
    + boosts -> `Repeat`
1. The check mark before "Show replies" is still present
    Pass `off` instead of `mixed` to `CheckboxItem`

<img width=500 src=https://user-images.githubusercontent.com/1430856/208326456-3e42ed43-2cda-430a-95b6-457821debaf6.jpg>