### PR TITLE
Update subtitle.txt

### DIFF
--- a/fastlane/metadata/it/subtitle.txt
+++ b/fastlane/metadata/it/subtitle.txt
@@ -1,1 +1,1 @@
-Client open source per Mastodon
+App open source per Mastodon


### PR DESCRIPTION
App Store says subtitle cannot be longer than 30 chars.. So many limitations 😂