### PR TITLE
Use lowercase "via" instead of distracting "Via"

### DIFF
--- a/src/i18n/en/components/timeline.json
+++ b/src/i18n/en/components/timeline.json
@@ -115,7 +115,7 @@
             "accessibilityHint": "User's account"
           }
         },
-        "application": "Via {{application}}",
+        "application": "via {{application}}",
         "edited": {
           "accessibilityLabel": "Toot edited"
         },


### PR DESCRIPTION
`Via xxx` with a capital V is a bit distracting and abrupt in the context.

IMHO `via` would look more harmoniously here when being put together with timestamp:

before: 1 hour ago Via tooot
&nbsp;&nbsp; after: 1 hour ago via tooot

<img src=https://user-images.githubusercontent.com/1430856/209481683-41bf2017-748b-4383-80ce-3eb14a88f513.jpeg width=350>