### PR TITLE
Fix README.md build status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![GPL-3.0](https://img.shields.io/github/license/tooot-app/push)](LICENSE) ![GitHub issues](https://img.shields.io/github/issues/tooot-app/app) ![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/tooot-app/app?include_prereleases) [![Crowdin](https://badges.crowdin.net/tooot/localized.svg)](https://crowdin.tooot.app/project/tooot)
 
-![GitHub Workflow Status (candidate)](https://img.shields.io/github/workflow/status/tooot-app/app/build/candidate?label=build%20candidate) ![GitHub Workflow Status (release)](https://img.shields.io/github/workflow/status/tooot-app/app/build/release?label=build%20release)
+![GitHub Workflow Status (candidate)](https://img.shields.io/github/actions/workflow/status/tooot-app/app/build.yml?branch=candidate&label=build%20candidate) ![GitHub Workflow Status (release)](https://img.shields.io/github/actions/workflow/status/tooot-app/app/build.yml?branch=release&label=build%20release)
 
 ## Contribute to translation
 

--- a/README.md
+++ b/README.md
@@ -11,28 +11,16 @@ Please **do not** create a pull request to update translation. tooot's translati
 
 ## Special thanks
 
-[@amrtf](https://crowdin.com/profile/amrtf) for Catalan and Spanish translation
-
-[@forenta](https://github.com/forenta) for German translation
-
-[@pat](https://piaille.fr/@pat) for French translation
-
-[@andrigamerita](https://github.com/andrigamerita) for Italian translation
-
-[@Hikaru](https://github.com/Hikali-47041) and [@la_la](https://mstdn.jp/@la_la_la) for Japanese translation
-
-[@hellojaccc](https://github.com/hellojaccc) for Korean translation
-
-[@jan-vandenberg](https://crowdin.com/profile/jan-vandenberg) for Dutch translation
-
-[@luizpicolo](https://github.com/luizpicolo) for Brazilian Portuguese
-
-[@janlindblom](https://github.com/janlindblom) for Swedish
-
-[@ihoryan](https://crowdin.com/profile/ihoryan) for Ukrainian
-
-[@duy@mas.to](https://mas.to/@duy) for Vietnamese translation
-
-[@jimmyorz](https://github.com/jimmyorz) for Traditional Chinese translation
-
-[@jk@mastodon.social](https://mastodon.social/@jk) for the famous Mastodon boop sound
+- [@amrtf](https://crowdin.com/profile/amrtf) for Catalan and Spanish translation
+- [@forenta](https://github.com/forenta) for German translation
+- [@pat](https://piaille.fr/@pat) for French translation
+- [@andrigamerita](https://github.com/andrigamerita) for Italian translation
+- [@Hikaru](https://github.com/Hikali-47041) and [@la_la](https://mstdn.jp/@la_la_la) for Japanese translation
+- [@hellojaccc](https://github.com/hellojaccc) for Korean translation
+- [@jan-vandenberg](https://crowdin.com/profile/jan-vandenberg) for Dutch translation
+- [@luizpicolo](https://github.com/luizpicolo) for Brazilian Portuguese
+- [@janlindblom](https://github.com/janlindblom) for Swedish
+- [@ihoryan](https://crowdin.com/profile/ihoryan) for Ukrainian
+- [@duy@mas.to](https://mas.to/@duy) for Vietnamese translation
+- [@jimmyorz](https://github.com/jimmyorz) for Traditional Chinese translation
+- [@jk@mastodon.social](https://mastodon.social/@jk) for the famous Mastodon boop sound


### PR DESCRIPTION
Update build status badges per https://github.com/badges/shields/issues/8671

From this:

<img width="500" alt="image" src="https://user-images.githubusercontent.com/1430856/209482910-050af72d-1d05-4aab-8d49-707afc197768.png">

to this:

<img width="350" alt="image" src="https://user-images.githubusercontent.com/1430856/209482922-086a8919-2f87-4d65-9c50-9ea878026896.png">

---

Also make the "Special thanks" section more visually compact.

---

Take a look here: https://github.com/tooot-app/app/blob/b0a95b07c94a82c2fdd01feb0965cf8513fd711f/README.md