### PR TITLE
OAuth: send PKCE code verifier with token request

### DIFF
--- a/src/components/Instance/index.tsx
+++ b/src/components/Instance/index.tsx
@@ -95,7 +95,10 @@ const ComponentInstance: React.FC<Props> = ({
             scopes: ['read', 'write', 'follow', 'push'],
             redirectUri,
             code: promptResult.params.code,
-            extraParams: { grant_type: 'authorization_code', code_verifier: request.codeVerifier }
+            extraParams: {
+              grant_type: 'authorization_code',
+              ...(request.codeVerifier && { code_verifier: request.codeVerifier })
+            }
           },
           { tokenEndpoint: `https://${variables.domain}/oauth/token` }
         )

--- a/src/components/Instance/index.tsx
+++ b/src/components/Instance/index.tsx
@@ -95,7 +95,7 @@ const ComponentInstance: React.FC<Props> = ({
             scopes: ['read', 'write', 'follow', 'push'],
             redirectUri,
             code: promptResult.params.code,
-            extraParams: { grant_type: 'authorization_code' }
+            extraParams: { grant_type: 'authorization_code', code_verifier: request.codeVerifier }
           },
           { tokenEndpoint: `https://${variables.domain}/oauth/token` }
         )


### PR DESCRIPTION
This will help to sign in into non-Mastodon servers which implement Mastodon API. Underlying package `expo-auth-session` enables [PKCE](https://www.rfc-editor.org/rfc/rfc7636) by default and my OAuth server also have PKCE support, but for some reason they forgot to send required `code_verifier` parameter on the last step.  While it should be done by `expo-auth-session` itself, this is a quick workaround.